### PR TITLE
Remove incorrect ESP32 customization

### DIFF
--- a/Adafruit_Si7021.cpp
+++ b/Adafruit_Si7021.cpp
@@ -50,11 +50,7 @@ float Adafruit_Si7021::readHumidity(void) {
 
   Wire.write(SI7021_MEASRH_NOHOLD_CMD);
   uint8_t err = Wire.endTransmission();
-#ifdef ARDUINO_ARCH_ESP32
-  if(err != I2C_ERROR_CONTINUE) //ESP32 has to queue ReSTART operations.
-#else
   if (err != 0)
-#endif
     return NAN; //error
 
   uint32_t start = millis(); // start timeout
@@ -80,11 +76,7 @@ float Adafruit_Si7021::readTemperature(void) {
   Wire.write(SI7021_MEASTEMP_NOHOLD_CMD);
   uint8_t err = Wire.endTransmission();
 
-#ifdef ARDUINO_ARCH_ESP32
-  if (err != I2C_ERROR_CONTINUE) //ESP32 has to queue ReSTART operations.
-#else
   if(err != 0)
-#endif
     return NAN; //error
     
   uint32_t start = millis(); // start timeout


### PR DESCRIPTION
I2C `ReSTART` operations on ESP32 are queued and not executed until an i2c transaction with a `STOP` is processed. To indicate this queuing, `Wire.endTransmission(false);` or `Wire.requestFrom(id,size,false);` returns `I2C_ERROR_CONTINUE`.  The prior revision of this library added `ReSTART` error checking, BUT, did not use `ReSTART` operations.  So the error detection code was falsely detecting success as an error.