### PR TITLE
Update for Teensy4, check for device at address

### DIFF
--- a/Adafruit_Si7021.cpp
+++ b/Adafruit_Si7021.cpp
@@ -79,9 +79,7 @@ float Adafruit_Si7021::readHumidity() {
   if (err != 0)
     return NAN; //error
 
-#if defined(TEENSY40)
-  delay(20);
-#endif
+  delay(20);    // account for conversion time for reading humidity
 
   uint32_t start = millis(); // start timeout
   while(millis()-start < _TRANSACTION_TIMEOUT) {
@@ -113,9 +111,7 @@ float Adafruit_Si7021::readTemperature() {
   if (err != 0)
     return NAN; //error
 
-#if defined(TEENSY40)
-  delay(20);
-#endif
+  delay(20);    // account for conversion time for reading temperature
 
   uint32_t start = millis(); // start timeout
   while(millis()-start < _TRANSACTION_TIMEOUT) {

--- a/Adafruit_Si7021.cpp
+++ b/Adafruit_Si7021.cpp
@@ -51,6 +51,10 @@ Adafruit_Si7021::Adafruit_Si7021(TwoWire *theWire) {
  */
 bool Adafruit_Si7021::begin() {
   _wire->begin();
+  
+  _wire->beginTransmission(_i2caddr);
+  if (_wire->endTransmission())
+    return false;   // device not available at the expected address
 
   reset();
   if (_readRegister8(SI7021_READRHT_REG_CMD) != 0x3A)
@@ -71,8 +75,13 @@ float Adafruit_Si7021::readHumidity() {
 
   _wire->write(SI7021_MEASRH_NOHOLD_CMD);
   uint8_t err = _wire->endTransmission();
+
   if (err != 0)
     return NAN; //error
+
+#if defined(TEENSY40)
+  delay(20);
+#endif
 
   uint32_t start = millis(); // start timeout
   while(millis()-start < _TRANSACTION_TIMEOUT) {
@@ -101,9 +110,13 @@ float Adafruit_Si7021::readTemperature() {
   _wire->write(SI7021_MEASTEMP_NOHOLD_CMD);
   uint8_t err = _wire->endTransmission();
 
-  if(err != 0)
+  if (err != 0)
     return NAN; //error
-    
+
+#if defined(TEENSY40)
+  delay(20);
+#endif
+
   uint32_t start = millis(); // start timeout
   while(millis()-start < _TRANSACTION_TIMEOUT) {
     if (_wire->requestFrom(_i2caddr, 3) == 3) {


### PR DESCRIPTION
Adafruit_SI7021.cpp Updates:
 - return false in .begin() if device is not available before executing any other wire commands. Without this check, with the Teensy4, the code would hang in the wire methods.
 - Added delays only for Teensy4 in the read humidity and temperature methods or the code would hang in the wire methods.

Assuming this behavior is associated with the higher frequency of the Teensy4.

Tested with the device available/not available on the following boards:
Adafruit Feather HUZZAH with ESP8266
Adafruit HUZZAH32 – ESP32 Feather Board
Adafruit Feather M4 Express
PJRC Teensy 4.0 USB Development Board