### PR TITLE
Add support for sensor heater

### DIFF
--- a/Adafruit_Si7021.cpp
+++ b/Adafruit_Si7021.cpp
@@ -263,6 +263,32 @@ si_sensorType Adafruit_Si7021::getModel()
   return _model;
 }
 
+/*!
+ *  @brief  Enable/Disable sensor heater
+ */
+void Adafruit_Si7021::heater(bool h)
+{
+  uint8_t regValue = _readRegister8(SI7021_READRHT_REG_CMD);
+
+  if (h) {
+    regValue |= (1 << (SI7021_REG_HTRE_BIT));
+  }
+  else {
+    regValue &= ~(1 << (SI7021_REG_HTRE_BIT));
+  }
+  _writeRegister8(SI7021_WRITERHT_REG_CMD, regValue);
+}
+
+/*!
+ *  @brief  Return sensor heater state
+ *  @return heater state (TRUE = enabled, FALSE = disabled)
+ */
+bool Adafruit_Si7021::isHeaterEnabled()
+{
+  uint8_t regValue = _readRegister8(SI7021_READRHT_REG_CMD);
+  return (bool)bitRead(regValue, SI7021_REG_HTRE_BIT);
+}
+
 /*******************************************************************/
 
 void Adafruit_Si7021::_writeRegister8(uint8_t reg, uint8_t value) {

--- a/Adafruit_Si7021.h
+++ b/Adafruit_Si7021.h
@@ -28,25 +28,30 @@
 /*!
  *  I2C ADDRESS/BITS
  */
-#define SI7021_DEFAULT_ADDRESS	0x40
+#define SI7021_DEFAULT_ADDRESS 0x40
 
-#define SI7021_MEASRH_HOLD_CMD           0xE5 /**< Measure Relative Humidity, Hold Master Mode */
-#define SI7021_MEASRH_NOHOLD_CMD         0xF5 /**< Measure Relative Humidity, No Hold Master Mode */
-#define SI7021_MEASTEMP_HOLD_CMD         0xE3 /**< Measure Temperature, Hold Master Mode */
-#define SI7021_MEASTEMP_NOHOLD_CMD       0xF3 /**< Measure Temperature, No Hold Master Mode */
-#define SI7021_READPREVTEMP_CMD          0xE0 /**< Read Temperature Value from Previous RH Measurement */
-#define SI7021_RESET_CMD                 0xFE /**< Reset Command */
-#define SI7021_WRITERHT_REG_CMD          0xE6 /**< Write RH/T User Register 1 */
-#define SI7021_READRHT_REG_CMD           0xE7 /**< Read RH/T User Register 1 */
-#define SI7021_WRITEHEATER_REG_CMD       0x51 /**< Write Heater Control Register */
-#define SI7021_READHEATER_REG_CMD        0x11 /**< Read Heater Control Register */
-#define SI7021_REG_HTRE_BIT              0x02 /**< Control Register Heater Bit */
-#define SI7021_ID1_CMD                   0xFA0F /**< Read Electronic ID 1st Byte */
-#define SI7021_ID2_CMD                   0xFCC9 /**< Read Electronic ID 2nd Byte */
-#define SI7021_FIRMVERS_CMD              0x84B8 /**< Read Firmware Revision */
+#define SI7021_MEASRH_HOLD_CMD                                                 \
+  0xE5 /**< Measure Relative Humidity, Hold Master Mode */
+#define SI7021_MEASRH_NOHOLD_CMD                                               \
+  0xF5 /**< Measure Relative Humidity, No Hold Master Mode */
+#define SI7021_MEASTEMP_HOLD_CMD                                               \
+  0xE3 /**< Measure Temperature, Hold Master Mode */
+#define SI7021_MEASTEMP_NOHOLD_CMD                                             \
+  0xF3 /**< Measure Temperature, No Hold Master Mode */
+#define SI7021_READPREVTEMP_CMD                                                \
+  0xE0 /**< Read Temperature Value from Previous RH Measurement */
+#define SI7021_RESET_CMD 0xFE           /**< Reset Command */
+#define SI7021_WRITERHT_REG_CMD 0xE6    /**< Write RH/T User Register 1 */
+#define SI7021_READRHT_REG_CMD 0xE7     /**< Read RH/T User Register 1 */
+#define SI7021_WRITEHEATER_REG_CMD 0x51 /**< Write Heater Control Register */
+#define SI7021_READHEATER_REG_CMD 0x11  /**< Read Heater Control Register */
+#define SI7021_REG_HTRE_BIT 0x02        /**< Control Register Heater Bit */
+#define SI7021_ID1_CMD 0xFA0F           /**< Read Electronic ID 1st Byte */
+#define SI7021_ID2_CMD 0xFCC9           /**< Read Electronic ID 2nd Byte */
+#define SI7021_FIRMVERS_CMD 0x84B8      /**< Read Firmware Revision */
 
-#define SI7021_REV_1					0xff  /**< Sensor revision 1 */
-#define SI7021_REV_2					0x20  /**< Sensor revision 2 */
+#define SI7021_REV_1 0xff /**< Sensor revision 1 */
+#define SI7021_REV_2 0x20 /**< Sensor revision 2 */
 
 /** An enum to represent sensor types **/
 enum si_sensorType {
@@ -62,7 +67,7 @@ enum si_sensorType {
  *          Si7021 Sensor
  */
 class Adafruit_Si7021 {
- public:
+public:
   Adafruit_Si7021(TwoWire *theWire = &Wire);
   bool begin();
 
@@ -70,25 +75,25 @@ class Adafruit_Si7021 {
   void reset();
   void readSerialNumber();
   float readHumidity();
+
   /*!
   *  @brief  Enable/Disable the sensor heater
   *  @param h True to enable the heater, False to disable it.
   */  
   void heater(bool h);
   bool isHeaterEnabled();
-
+  
   /*!
-  *  @brief  Returns sensor revision established during init 
-  *  @return model value
-  */
-  uint8_t getRevision() { return _revision; }; 
+   *  @brief  Returns sensor revision established during init
+   *  @return model value
+   */
+  uint8_t getRevision() { return _revision; };
   si_sensorType getModel();
 
   uint32_t sernum_a; /**< Serialnum A */
   uint32_t sernum_b; /**< Serialnum B */
 
-
- private:
+private:
   void _readRevision();
   si_sensorType _model;
   uint8_t _revision;
@@ -96,7 +101,7 @@ class Adafruit_Si7021 {
   uint16_t _readRegister16(uint8_t reg);
   void _writeRegister8(uint8_t reg, uint8_t value);
 
-  int8_t  _i2caddr;
+  int8_t _i2caddr;
   TwoWire *_wire;
   const static int _TRANSACTION_TIMEOUT = 100; // Wire NAK/Busy timeout in ms
 };

--- a/Adafruit_Si7021.h
+++ b/Adafruit_Si7021.h
@@ -40,6 +40,7 @@
 #define SI7021_READRHT_REG_CMD           0xE7 /**< Read RH/T User Register 1 */
 #define SI7021_WRITEHEATER_REG_CMD       0x51 /**< Write Heater Control Register */
 #define SI7021_READHEATER_REG_CMD        0x11 /**< Read Heater Control Register */
+#define SI7021_REG_HTRE_BIT              0x02 /**< Control Register Heater Bit */
 #define SI7021_ID1_CMD                   0xFA0F /**< Read Electronic ID 1st Byte */
 #define SI7021_ID2_CMD                   0xFCC9 /**< Read Electronic ID 2nd Byte */
 #define SI7021_FIRMVERS_CMD              0x84B8 /**< Read Firmware Revision */
@@ -69,6 +70,8 @@ class Adafruit_Si7021 {
   void reset();
   void readSerialNumber();
   float readHumidity();
+  void heater(bool h);
+  bool isHeaterEnabled();
 
   /*!
   *  @brief  Returns sensor revision established during init 

--- a/Adafruit_Si7021.h
+++ b/Adafruit_Si7021.h
@@ -70,6 +70,10 @@ class Adafruit_Si7021 {
   void reset();
   void readSerialNumber();
   float readHumidity();
+  /*!
+  *  @brief  Enable/Disable the sensor heater
+  *  @param h True to enable the heater, False to disable it.
+  */  
   void heater(bool h);
   bool isHeaterEnabled();
 

--- a/examples/si7021/si7021.ino
+++ b/examples/si7021/si7021.ino
@@ -1,5 +1,8 @@
 #include "Adafruit_Si7021.h"
 
+bool enableHeater = false;
+uint8_t loopCnt = 0;
+
 Adafruit_Si7021 sensor = Adafruit_Si7021();
 
 void setup() {
@@ -44,4 +47,18 @@ void loop() {
   Serial.print("\tTemperature: ");
   Serial.println(sensor.readTemperature(), 2);
   delay(1000);
+
+  // Toggle heater enabled state every 30 seconds
+  // An ~1.8 degC temperature increase can be noted when heater is enabled
+  if (++loopCnt == 30) {
+    enableHeater = !enableHeater;
+    sensor.heater(enableHeater);
+    Serial.print("Heater Enabled State: ");
+    if (sensor.isHeaterEnabled())
+      Serial.println("ENABLED");
+    else
+      Serial.println("DISABLED");
+       
+    loopCnt = 0;
+  }
 }


### PR DESCRIPTION
Added support for enabling/disabling/checking sensor heater.
Updated example INO file to toggle the heater enabled state every 30 seconds.
Tested on the following boards using the updated example INO file in the PlatformIO environment:
 - Adafruit Feather HUZZAH
 - Adafruit HUZZAH32
 - Adafruit Grand Central M4 Express
 - Teensy 4.0
 - Adafruit METRO 328