### PR TITLE
Add support for sensor heater

### DIFF
--- a/Adafruit_Si7021.cpp
+++ b/Adafruit_Si7021.cpp
@@ -263,8 +263,7 @@ void Adafruit_Si7021::heater(bool h) {
 
   if (h) {
     regValue |= (1 << (SI7021_REG_HTRE_BIT));
-  }
-  else {
+  } else {
     regValue &= ~(1 << (SI7021_REG_HTRE_BIT));
   }
   _writeRegister8(SI7021_WRITERHT_REG_CMD, regValue);

--- a/Adafruit_Si7021.cpp
+++ b/Adafruit_Si7021.cpp
@@ -255,6 +255,30 @@ void Adafruit_Si7021::readSerialNumber() {
  */
 si_sensorType Adafruit_Si7021::getModel() { return _model; }
 
+/*!
+ *  @brief  Enable/Disable sensor heater
+ */
+void Adafruit_Si7021::heater(bool h) {
+  uint8_t regValue = _readRegister8(SI7021_READRHT_REG_CMD);
+
+  if (h) {
+    regValue |= (1 << (SI7021_REG_HTRE_BIT));
+  }
+  else {
+    regValue &= ~(1 << (SI7021_REG_HTRE_BIT));
+  }
+  _writeRegister8(SI7021_WRITERHT_REG_CMD, regValue);
+}
+
+/*!
+ *  @brief  Return sensor heater state
+ *  @return heater state (TRUE = enabled, FALSE = disabled)
+ */
+bool Adafruit_Si7021::isHeaterEnabled() {
+  uint8_t regValue = _readRegister8(SI7021_READRHT_REG_CMD);
+  return (bool)bitRead(regValue, SI7021_REG_HTRE_BIT);
+}
+
 /*******************************************************************/
 
 void Adafruit_Si7021::_writeRegister8(uint8_t reg, uint8_t value) {

--- a/Adafruit_Si7021.h
+++ b/Adafruit_Si7021.h
@@ -79,7 +79,7 @@ public:
   /*!
    *  @brief  Enable/Disable the sensor heater
    *  @param h True to enable the heater, False to disable it.
-   */  
+   */
   void heater(bool h);
   bool isHeaterEnabled();
 

--- a/Adafruit_Si7021.h
+++ b/Adafruit_Si7021.h
@@ -77,9 +77,9 @@ public:
   float readHumidity();
 
   /*!
-  *  @brief  Enable/Disable the sensor heater
-  *  @param h True to enable the heater, False to disable it.
-  */  
+   *  @brief  Enable/Disable the sensor heater
+   *  @param h True to enable the heater, False to disable it.
+   */  
   void heater(bool h);
   bool isHeaterEnabled();
 

--- a/Adafruit_Si7021.h
+++ b/Adafruit_Si7021.h
@@ -45,6 +45,7 @@
 #define SI7021_READRHT_REG_CMD 0xE7     /**< Read RH/T User Register 1 */
 #define SI7021_WRITEHEATER_REG_CMD 0x51 /**< Write Heater Control Register */
 #define SI7021_READHEATER_REG_CMD 0x11  /**< Read Heater Control Register */
+#define SI7021_REG_HTRE_BIT 0x02        /**< Control Register Heater Bit */
 #define SI7021_ID1_CMD 0xFA0F           /**< Read Electronic ID 1st Byte */
 #define SI7021_ID2_CMD 0xFCC9           /**< Read Electronic ID 2nd Byte */
 #define SI7021_FIRMVERS_CMD 0x84B8      /**< Read Firmware Revision */
@@ -74,6 +75,13 @@ public:
   void reset();
   void readSerialNumber();
   float readHumidity();
+
+  /*!
+  *  @brief  Enable/Disable the sensor heater
+  *  @param h True to enable the heater, False to disable it.
+  */  
+  void heater(bool h);
+  bool isHeaterEnabled();
 
   /*!
    *  @brief  Returns sensor revision established during init

--- a/examples/si7021/si7021.ino
+++ b/examples/si7021/si7021.ino
@@ -1,5 +1,8 @@
 #include "Adafruit_Si7021.h"
 
+bool enableHeater = false;
+uint8_t loopCnt = 0;
+
 Adafruit_Si7021 sensor = Adafruit_Si7021();
 
 void setup() {
@@ -44,4 +47,18 @@ void loop() {
   Serial.print("\tTemperature: ");
   Serial.println(sensor.readTemperature(), 2);
   delay(1000);
+
+  // Toggle heater enabled state every 30 seconds
+  // An ~1.8 degC temperature increase can be noted when heater is enabled
+  if (++loopCnt == 30) {
+    enableHeater = !enableHeater;
+    sensor.heater(enableHeater);
+    Serial.print("Heater Enabled State: ");
+    if (sensor.isHeaterEnabled())
+      Serial.println("ENABLED");
+    else
+      Serial.println("DISABLED");
+       
+    loopCnt = 0;
+  }
 }


### PR DESCRIPTION
Added support for enabling/disabling/checking sensor heater.
Updated example INO file to toggle the heater enabled state every 30 seconds.
Tested on the following boards using the updated example INO file in the PlatformIO environment:

- Adafruit Feather HUZZAH
- Adafruit HUZZAH32
- Adafruit Grand Central M4 Express
- Teensy 4.0
- Adafruit METRO 328
