### PR TITLE
Convert to BusIO

### DIFF
--- a/Adafruit_Si7021.cpp
+++ b/Adafruit_Si7021.cpp
@@ -29,7 +29,6 @@
 
 #include "Arduino.h"
 #include <Adafruit_Si7021.h>
-#include <Wire.h>
 
 /*!
  *  @brief  Instantiates a new Adafruit_Si7021 class
@@ -37,10 +36,10 @@
  *          optional wire object
  */
 Adafruit_Si7021::Adafruit_Si7021(TwoWire *theWire) {
-  _i2caddr = SI7021_DEFAULT_ADDRESS;
-  _wire = theWire;
+  i2c_dev = new Adafruit_I2CDevice(SI7021_DEFAULT_ADDRESS, theWire);
+
   sernum_a = sernum_b = 0;
-  _model = SI_7021;
+  _model = SI_UNKNOWN;
   _revision = 0;
 }
 
@@ -50,11 +49,8 @@ Adafruit_Si7021::Adafruit_Si7021(TwoWire *theWire) {
  *  @return Returns true if set up is successful.
  */
 bool Adafruit_Si7021::begin() {
-  _wire->begin();
-
-  _wire->beginTransmission(_i2caddr);
-  if (_wire->endTransmission())
-    return false; // device not available at the expected address
+  if (!i2c_dev->begin())
+    return false;
 
   reset();
   if (_readRegister8(SI7021_READRHT_REG_CMD) != 0x3A)
@@ -71,21 +67,18 @@ bool Adafruit_Si7021::begin() {
  *  @return Returns humidity as float value or NAN when there is error timeout
  */
 float Adafruit_Si7021::readHumidity() {
-  _wire->beginTransmission(_i2caddr);
+  uint8_t buffer[3] = {SI7021_MEASRH_NOHOLD_CMD, 0, 0};
 
-  _wire->write(SI7021_MEASRH_NOHOLD_CMD);
-  uint8_t err = _wire->endTransmission();
-
-  if (err != 0)
-    return NAN; // error
+  if (!i2c_dev->write(buffer, 1))
+    return NAN;
 
   delay(20); // account for conversion time for reading humidity
 
   uint32_t start = millis(); // start timeout
   while (millis() - start < _TRANSACTION_TIMEOUT) {
-    if (_wire->requestFrom(_i2caddr, 3) == 3) {
-      uint16_t hum = _wire->read() << 8 | _wire->read();
-      uint8_t chxsum = _wire->read();
+    if (i2c_dev->read(buffer, 3)) {
+      uint16_t hum = buffer[0] << 8 | buffer[1];
+      // uint8_t chxsum = buffer[2];
 
       float humidity = hum;
       humidity *= 125;
@@ -105,20 +98,18 @@ float Adafruit_Si7021::readHumidity() {
  * timeout
  */
 float Adafruit_Si7021::readTemperature() {
-  _wire->beginTransmission(_i2caddr);
-  _wire->write(SI7021_MEASTEMP_NOHOLD_CMD);
-  uint8_t err = _wire->endTransmission();
+  uint8_t buffer[3] = {SI7021_MEASTEMP_NOHOLD_CMD, 0, 0};
 
-  if (err != 0)
-    return NAN; // error
+  if (!i2c_dev->write(buffer, 1))
+    return NAN;
 
   delay(20); // account for conversion time for reading temperature
 
   uint32_t start = millis(); // start timeout
   while (millis() - start < _TRANSACTION_TIMEOUT) {
-    if (_wire->requestFrom(_i2caddr, 3) == 3) {
-      uint16_t temp = _wire->read() << 8 | _wire->read();
-      uint8_t chxsum = _wire->read();
+    if (i2c_dev->read(buffer, 3)) {
+      uint16_t temp = buffer[0] << 8 | buffer[1];
+      // uint8_t chxsum = buffer[2];
 
       float temperature = temp;
       temperature *= 175.72;
@@ -136,101 +127,56 @@ float Adafruit_Si7021::readTemperature() {
  *  @brief  Sends the reset command to Si7021.
  */
 void Adafruit_Si7021::reset() {
-  _wire->beginTransmission(_i2caddr);
-  _wire->write(SI7021_RESET_CMD);
-  _wire->endTransmission();
+  uint8_t buffer[1] = {SI7021_RESET_CMD};
+  i2c_dev->write(buffer, 1);
+
   delay(50);
 }
 
 void Adafruit_Si7021::_readRevision(void) {
-  _wire->beginTransmission(_i2caddr);
-  _wire->write((uint8_t)(SI7021_FIRMVERS_CMD >> 8));
-  _wire->write((uint8_t)(SI7021_FIRMVERS_CMD & 0xFF));
-  _wire->endTransmission();
+  uint8_t buffer[2] = {(uint8_t)(SI7021_FIRMVERS_CMD >> 8),
+                       (uint8_t)(SI7021_FIRMVERS_CMD & 0xFF)};
 
-  uint32_t start = millis(); // start timeout
-  while (millis() - start < _TRANSACTION_TIMEOUT) {
-    if (_wire->requestFrom(_i2caddr, 2) == 2) {
-      uint8_t rev = _wire->read();
-      _wire->read();
+  i2c_dev->write_then_read(buffer, 2, buffer, 1);
 
-      if (rev == SI7021_REV_1) {
-        rev = 1;
-      } else if (rev == SI7021_REV_2) {
-        rev = 2;
-      }
-      _revision = rev;
-      return;
-    }
-    delay(2);
+  switch (buffer[0]) {
+  case SI7021_REV_1:
+    _revision = 1;
+    break;
+  case SI7021_REV_2:
+    _revision = 2;
+    break;
+  default:
+    _revision = 0;
   }
-  _revision = 0;
-  return; // Error timeout
 }
 
 /*!
  *  @brief  Reads serial number and stores It in sernum_a and sernum_b variable
  */
 void Adafruit_Si7021::readSerialNumber() {
-  _wire->beginTransmission(_i2caddr);
-  _wire->write((uint8_t)(SI7021_ID1_CMD >> 8));
-  _wire->write((uint8_t)(SI7021_ID1_CMD & 0xFF));
-  _wire->endTransmission();
+  uint8_t buffer[8];
 
-  bool gotData = false;
-  uint32_t start = millis(); // start timeout
-  while (millis() - start < _TRANSACTION_TIMEOUT) {
-    if (_wire->requestFrom(_i2caddr, 8) == 8) {
-      gotData = true;
-      break;
-    }
-    delay(2);
-  }
-  if (!gotData)
-    return; // error timeout
+  //
+  // SNA
+  //
+  buffer[0] = (uint8_t)(SI7021_ID1_CMD >> 8);
+  buffer[1] = (uint8_t)(SI7021_ID1_CMD & 0xFF);
+  i2c_dev->write_then_read(buffer, 2, buffer, 8);
+  sernum_a = uint32_t(buffer[0]) << 24 | uint32_t(buffer[2]) << 16 |
+             uint32_t(buffer[4]) << 8 | uint32_t(buffer[6]);
 
-  sernum_a = _wire->read();
-  _wire->read();
-  sernum_a <<= 8;
-  sernum_a |= _wire->read();
-  _wire->read();
-  sernum_a <<= 8;
-  sernum_a |= _wire->read();
-  _wire->read();
-  sernum_a <<= 8;
-  sernum_a |= _wire->read();
-  _wire->read();
+  //
+  // SNB
+  //
+  buffer[0] = (uint8_t)(SI7021_ID2_CMD >> 8);
+  buffer[1] = (uint8_t)(SI7021_ID2_CMD & 0xFF);
+  i2c_dev->write_then_read(buffer, 2, buffer, 6);
+  sernum_a = uint32_t(buffer[0]) << 24 | uint32_t(buffer[1]) << 16 |
+             uint32_t(buffer[4]) << 8 | uint32_t(buffer[5]);
 
-  _wire->beginTransmission(_i2caddr);
-  _wire->write((uint8_t)(SI7021_ID2_CMD >> 8));
-  _wire->write((uint8_t)(SI7021_ID2_CMD & 0xFF));
-  _wire->endTransmission();
-
-  gotData = false;
-  start = millis(); // start timeout
-  while (millis() - start < _TRANSACTION_TIMEOUT) {
-    if (_wire->requestFrom(_i2caddr, 8) == 8) {
-      gotData = true;
-      break;
-    }
-    delay(2);
-  }
-  if (!gotData)
-    return; // error timeout
-
-  sernum_b = _wire->read();
-  _wire->read();
-  sernum_b <<= 8;
-  sernum_b |= _wire->read();
-  _wire->read();
-  sernum_b <<= 8;
-  sernum_b |= _wire->read();
-  _wire->read();
-  sernum_b <<= 8;
-  sernum_b |= _wire->read();
-  _wire->read();
-
-  switch (sernum_b >> 24) {
+  // Use SNB3 for device model version
+  switch (buffer[0]) {
   case 0:
   case 0xff:
     _model = SI_Engineering_Samples;
@@ -288,46 +234,15 @@ void Adafruit_Si7021::setHeatLevel(uint8_t level) {
 /*******************************************************************/
 
 void Adafruit_Si7021::_writeRegister8(uint8_t reg, uint8_t value) {
-  _wire->beginTransmission(_i2caddr);
-  _wire->write(reg);
-  _wire->write(value);
-  _wire->endTransmission();
+  uint8_t buffer[2] = {reg, value};
+  i2c_dev->write(buffer, 2);
 
   // Serial.print("Wrote $"); Serial.print(reg, HEX); Serial.print(": 0x");
   // Serial.println(value, HEX);
 }
 
 uint8_t Adafruit_Si7021::_readRegister8(uint8_t reg) {
-  uint8_t value;
-  _wire->beginTransmission(_i2caddr);
-  _wire->write((uint8_t)reg);
-  _wire->endTransmission();
-
-  uint32_t start = millis(); // start timeout
-  while (millis() - start < _TRANSACTION_TIMEOUT) {
-    if (_wire->requestFrom(_i2caddr, 1) == 1) {
-      value = _wire->read();
-      return value;
-    }
-    delay(2);
-  }
-
-  return 0; // Error timeout
-}
-
-uint16_t Adafruit_Si7021::_readRegister16(uint8_t reg) {
-  uint16_t value;
-  _wire->beginTransmission(_i2caddr);
-  _wire->write(reg);
-  _wire->endTransmission(false);
-
-  uint32_t start = millis(); // start timeout
-  while (millis() - start < _TRANSACTION_TIMEOUT) {
-    if (_wire->requestFrom(_i2caddr, 2) == 2) {
-      value = _wire->read() << 8 | _wire->read();
-      return value;
-    }
-    delay(2);
-  }
-  return 0; // Error timeout
+  uint8_t buffer[1] = {reg};
+  i2c_dev->write_then_read(buffer, 1, buffer, 1);
+  return buffer[0];
 }

--- a/Adafruit_Si7021.h
+++ b/Adafruit_Si7021.h
@@ -23,7 +23,7 @@
 #define __Si7021_H__
 
 #include "Arduino.h"
-#include <Wire.h>
+#include <Adafruit_I2CDevice.h>
 
 /*!
  *  I2C ADDRESS/BITS
@@ -114,11 +114,9 @@ private:
   si_sensorType _model;
   uint8_t _revision;
   uint8_t _readRegister8(uint8_t reg);
-  uint16_t _readRegister16(uint8_t reg);
   void _writeRegister8(uint8_t reg, uint8_t value);
 
-  int8_t _i2caddr;
-  TwoWire *_wire;
+  Adafruit_I2CDevice *i2c_dev = NULL;          ///< Pointer to I2C bus interface
   const static int _TRANSACTION_TIMEOUT = 100; // Wire NAK/Busy timeout in ms
 };
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit Si7021 Library
-version=1.4.0
+version=1.5.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for Si7021 sensors.
@@ -7,3 +7,4 @@ paragraph=Arduino library for Si7021 temperature + humidity sensors.
 category=Sensors
 url=https://github.com/adafruit/Adafruit_Si7021
 architectures=*
+depends=Adafruit BusIO


### PR DESCRIPTION
For #22.

There was a fair amount of customy looking I2C xfer code in here, with loops and delays. But everything seems to work OK using basic BusIO methods. Datasheet doesn't show anything special, expect for the use of NACK to indicate conversion not complete (instead of clock stretching thank you!). Those loops (one each for humidity and temperature) are still in place.

Tested on QtPy with library example.

![Screenshot from 2021-10-07 16-18-07](https://user-images.githubusercontent.com/8755041/136475200-6afcc001-de8f-460d-a0a5-3138957b73e5.png)

